### PR TITLE
Email & Password Validation

### DIFF
--- a/lib/login.dart
+++ b/lib/login.dart
@@ -107,7 +107,7 @@ class _LoginPageState extends State<LoginPage> {
                       SizedBox(height: 20),
                       Text(
                         'Welcome back! Login with your credentials',
-                        style: TextStyle(fontSize: 15, color: Colors.blueGrey),
+                        style: TextStyle(fontSize: 15, color: Colors.black),
                       ),
                       SizedBox(
                         height: 30,
@@ -167,9 +167,11 @@ class _LoginPageState extends State<LoginPage> {
                           //and password meet the criteria
 
                           if (!isEmailValid(email)) {
-                            showErrorDialog(context, 'Invalid email address');
+                            showErrorDialog(context, 'Invalid email address.');
+                            return;
                           } else if (!sPValid(password)) {
-                            showErrorDialog(context, 'Invalid password');
+                            showErrorDialog(context, 'Invalid password.');
+                            return;
                           } else {
                             Navigator.pushNamed(context, '/map');
                           }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -8,10 +8,15 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  final TextEditingController emailcontroller = TextEditingController();
-  final TextEditingController passwordcontroller = TextEditingController();
+  final TextEditingController firstNameController = TextEditingController();
+  final TextEditingController lastNameController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController confirmEmailController = TextEditingController();
+  final TextEditingController currentPWController = TextEditingController();
+  final TextEditingController newPWController = TextEditingController();
+  final TextEditingController confirmPWController = TextEditingController();
 
-//Createria that email mus follow
+  // Createria that email must follow
   bool isEmailValid(String email) {
     String emailPattern = r'^[\w-]+(\.[\w-]+)*@[\w-]+(\.[\w-]+)*(\.[a-z]{2,})$';
     RegExp regExp = RegExp(emailPattern);
@@ -137,7 +142,6 @@ class _SettingsPageState extends State<SettingsPage> {
                     minWidth: double.infinity,
                     height: 60,
                     onPressed: () {
-                      // TODO create dialog box to change password
                       _showChangePasswordDialog();
                     },
                     color: Colors.lightBlue[800],
@@ -166,8 +170,6 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   // Function to show the "Change Name" dialog
-  final TextEditingController firstNameController = TextEditingController();
-  final TextEditingController lastNameController = TextEditingController();
   void _showChangeNameDialog() {
     firstNameController.clear();
     lastNameController.clear();
@@ -216,8 +218,6 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
-  final TextEditingController emailController = TextEditingController();
-  final TextEditingController confirmEmailController = TextEditingController();
   // Function to show the "Change Email" dialog box
   void _showChangeEmailDialog() {
     // clear out any previous input
@@ -280,9 +280,6 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 
-  final TextEditingController currentPWController = TextEditingController();
-  final TextEditingController newPWController = TextEditingController();
-  final TextEditingController confirmPWController = TextEditingController();
   // Function to show the "Change Password" dialog box
   void _showChangePasswordDialog() {
     // clear out any previous input

--- a/lib/signup.dart
+++ b/lib/signup.dart
@@ -1,7 +1,63 @@
 import 'package:flutter/material.dart';
 
-class SignUpPage extends StatelessWidget {
+class SignUpPage extends StatefulWidget {
   const SignUpPage({super.key});
+
+  @override
+  State<SignUpPage> createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  final TextEditingController firstNameController = TextEditingController();
+  final TextEditingController lastNameController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController newPWController = TextEditingController();
+  final TextEditingController confirmPWController = TextEditingController();
+
+  // Createria that email must follow
+  bool isEmailValid(String email) {
+    String emailPattern = r'^[\w-]+(\.[\w-]+)*@[\w-]+(\.[\w-]+)*(\.[a-z]{2,})$';
+    RegExp regExp = RegExp(emailPattern);
+
+    return regExp.hasMatch(email);
+  }
+
+  bool sPValid(String password) {
+    // Check password length (at least 8 characters)
+    if (password.length < 8) {
+      return false;
+    }
+    RegExp upperCaseRegExp = RegExp(r'[A-Z]');
+    RegExp lowerCaseRegExp = RegExp(r'[a-z]');
+    RegExp digitRegExp = RegExp(r'[0-9]');
+
+    if (!upperCaseRegExp.hasMatch(password) ||
+        !lowerCaseRegExp.hasMatch(password) ||
+        !digitRegExp.hasMatch(password)) {
+      return false;
+    }
+    return true;
+  }
+
+  void showErrorDialog(BuildContext context, String message) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Error'),
+          content: Text(message),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,12 +125,22 @@ class SignUpPage extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(horizontal: 40),
                       child: Column(
                         children: [
-                          makeInput(label: "First Name"),
-                          makeInput(label: "Last Name"),
-                          makeInput(label: "Email"),
-                          makeInput(label: "Password", obscureText: true),
                           makeInput(
-                              label: "Confirm Password", obscureText: true),
+                              label: "First Name",
+                              controller: firstNameController),
+                          makeInput(
+                              label: "Last Name",
+                              controller: lastNameController),
+                          makeInput(
+                              label: "Email", controller: emailController),
+                          makeInput(
+                              label: "Password",
+                              obscureText: true,
+                              controller: newPWController),
+                          makeInput(
+                              label: "Confirm Password",
+                              obscureText: true,
+                              controller: confirmPWController),
                         ],
                       ),
                     ),
@@ -89,7 +155,23 @@ class SignUpPage extends StatelessWidget {
                           minWidth: double.infinity,
                           height: 60,
                           onPressed: () {
-                            Navigator.pushNamed(context, '/login');
+                            String email = emailController.text;
+                            String password = newPWController.text;
+                            String confirmPassword = confirmPWController.text;
+                            if (!isEmailValid(email)) {
+                              showErrorDialog(
+                                  context, 'Invalid email address.');
+                              return;
+                            } else if (password != confirmPassword) {
+                              showErrorDialog(
+                                  context, 'Passwords do not match.');
+                              return;
+                            } else if (!sPValid(password)) {
+                              showErrorDialog(context, 'Invalid password.');
+                              return;
+                            } else {
+                              Navigator.pushNamed(context, '/login');
+                            }
                           },
                           color: Colors.lightBlue[800],
                           shape: RoundedRectangleBorder(
@@ -136,7 +218,8 @@ class SignUpPage extends StatelessWidget {
   }
 }
 
-Widget makeInput({label, obscureText = false}) {
+Widget makeInput(
+    {label, obscureText = false, required TextEditingController controller}) {
   return Column(
     crossAxisAlignment: CrossAxisAlignment.start,
     children: [
@@ -149,6 +232,7 @@ Widget makeInput({label, obscureText = false}) {
         height: 3,
       ),
       TextField(
+        controller: controller,
         obscureText: obscureText,
         decoration: const InputDecoration(
           contentPadding: EdgeInsets.symmetric(vertical: 0, horizontal: 10),


### PR DESCRIPTION
Create more functionality for email and password criteria validation.

* Added dialog boxes to show user an error when their email and/or password doesn't meet the criteria
* Added checks to make sure email/confirm email and password/confirm password actually match
* Show user an error dialog box when it doesn't match
* Add all email/password criteria validation and match checking to settings page.
