### PR TITLE
Use `outdoors` layer group for map screen

### DIFF
--- a/lib/map.dart
+++ b/lib/map.dart
@@ -44,8 +44,8 @@ class _MapPageState extends State<MapPage> {
             children: [
               TileLayer(
                 wmsOptions: WMSTileLayerOptions(
-                  baseUrl: "http://164.92.112.125:8080/geoserver/wms/?",
-                  layers: const ["Satellite_Imagery:high_res_campus_imagery"],
+                  baseUrl: "http://144.126.221.0:8080/geoserver/wms/?",
+                  layers: const ["outdoors"],
                 ),
               ),
             ],


### PR DESCRIPTION
In the future, the `outdoors` layer group should contain any outdoor features of the campus map, like building boxes, paths, and other attractions. This update temporarily hard-codes the map's layer(s) to `["outdoors"]`.